### PR TITLE
Fix app.say

### DIFF
--- a/EightyApp.js
+++ b/EightyApp.js
@@ -25,9 +25,7 @@ var EightyApp = function() {
      * @param {String} msg The string to output
      */
     this.say = function(msg) {
-        process.send({
-            message: msg.toString()
-        })
+        console.log('app.say has been deprecated, please use `console.log` instead');
     }
     
     this.version = "2.0";


### PR DESCRIPTION
`app.say` no longer really does anything, we just need to use `console.log` instead.

I've added a deprecation log, we can keep that for the time being until we decide it's safe to remove it in the future or something.